### PR TITLE
Fixes issues with not saving a file content_type and other issues

### DIFF
--- a/lib/fog/storage/backblaze/models/file.rb
+++ b/lib/fog/storage/backblaze/models/file.rb
@@ -2,7 +2,7 @@ class Fog::Storage::Backblaze::File < Fog::Model
 
   identity :file_name, aliases: %w{fileName key name}
 
-  attribute :content_length, aliases: 'contentLength'
+  attribute :content_length, aliases: 'contentLength', :type => :integer
   attribute :content_type, aliases: 'contentType'
   attribute :file_id, aliases: 'fileId'
   attribute :file_info, aliases: 'fileInfo'

--- a/lib/fog/storage/backblaze/models/files.rb
+++ b/lib/fog/storage/backblaze/models/files.rb
@@ -46,7 +46,7 @@ class Fog::Storage::Backblaze::Files < Fog::Collection
   def head(file_name, options = {})
     requires :directory
     data = service.head_object(directory.key, file_name, options)
-    file_data = _headers_to_attrs(file_response)
+    file_data = _headers_to_attrs(data)
     new(file_data)
   rescue Excon::Errors::NotFound
     nil
@@ -54,11 +54,11 @@ class Fog::Storage::Backblaze::Files < Fog::Collection
 
   def _headers_to_attrs(file_response)
     {
-      fileName:        file_response.headers['x-bz-file-name'],
-      fileId:          file_response.headers['x-bz-file-id'],
-      uploadTimestamp: file_response.headers['X-Bz-Upload-Timestamp'],
-      contentType:     file_response.headers['Content-Type'],
-      contentLength:   file_response.headers['Content-Length']
+      'fileName'        => file_response.headers['x-bz-file-name'],
+      'fileId'          => file_response.headers['x-bz-file-id'],
+      'uploadTimestamp' => file_response.headers['X-Bz-Upload-Timestamp'],
+      'contentType'     => file_response.headers['Content-Type'],
+      'contentLength'   => file_response.headers['Content-Length']
     }
   end
 

--- a/lib/fog/storage/backblaze/real.rb
+++ b/lib/fog/storage/backblaze/real.rb
@@ -145,7 +145,7 @@ class Fog::Storage::Backblaze::Real
     }.merge(options))
   end
 
-  def head_object(bucket_name, file_path)
+  def head_object(bucket_name, file_path, options = {})
     file_url = get_object_url(bucket_name, file_path)
 
     result = b2_command(nil,


### PR DESCRIPTION
This pull request addresses several issues:

- Correctly convert headers to attributes (e.g. fileName, fileId, etc.)
- Fixed head_object method to take three arguments
- Appropriately set content_type attribute to :integer for later conversion
