### PR TITLE
Don't print JSON response on first call to b2_account_id

### DIFF
--- a/lib/fog/backblaze/storage/real.rb
+++ b/lib/fog/backblaze/storage/real.rb
@@ -501,8 +501,6 @@ class Fog::Backblaze::Storage::Real
   def b2_account_id
     return @options[:b2_account_id] if @options[:b2_account_id]
 
-    auth = auth_response
-    p auth
-    auth['accountId']
+    auth_response['accountId']
   end
 end


### PR DESCRIPTION
Remove a call to print the JSON response from `auth_info`

Fixes #12 