### PR TITLE
Fix token_cache option and add tests

### DIFF
--- a/lib/fog/backblaze/storage/real.rb
+++ b/lib/fog/backblaze/storage/real.rb
@@ -12,8 +12,8 @@ class Fog::Backblaze::Storage::Real
       Fog::Backblaze::TokenCache.new
     elsif options[:token_cache] === false
       Fog::Backblaze::TokenCache::NullTokenCache.new
-    elsif token_cache.is_a?(Fog::Backblaze::TokenCache)
-      token_cache
+    elsif options[:token_cache].is_a?(Fog::Backblaze::TokenCache)
+      options[:token_cache]
     else
       Fog::Backblaze::TokenCache::FileTokenCache.new(options[:token_cache])
     end

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -1,0 +1,53 @@
+require_relative "test_helper"
+
+class TestTokenCache < Fog::Backblaze::TokenCache; end
+
+describe "cache implementations" do
+
+  it "should set @token_cache = :memory if no token_cache option provided" do
+    connection = Fog::Storage.new(
+      provider: 'backblaze'
+    )
+
+    assert_equal(connection.token_cache.is_a?(Fog::Backblaze::TokenCache), true)
+  end
+
+  it "should set @token_cache = :memory if token_cache option is `nil`" do
+    connection = Fog::Storage.new(
+      provider: 'backblaze',
+      token_cache: nil,
+    )
+
+    assert_equal(connection.token_cache.is_a?(Fog::Backblaze::TokenCache), true)
+  end
+
+  it "should set @token_cache = :memory if token_cache option is `false`" do
+    connection = Fog::Storage.new(
+      provider: 'backblaze',
+      token_cache: false,
+    )
+
+    assert_equal(connection.token_cache.is_a?(Fog::Backblaze::TokenCache::NullTokenCache), true)
+  end
+
+  it "should set @token_cache = <provided token cache> if token_cache option is a `Fog::Backblaze::TokenCache`" do
+    cache = TestTokenCache.new
+
+    connection = Fog::Storage.new(
+      provider: 'backblaze',
+      token_cache: cache
+    )
+
+    assert_equal(connection.token_cache, cache)
+  end
+
+  it "should set @token_cache = Fog::Backblaze::TokenCache::FileTokenCache if token_cache option is a String" do
+    connection = Fog::Storage.new(
+      provider: 'backblaze',
+      token_cache: 'file.txt',
+    )
+
+    assert_equal(connection.token_cache.is_a?(Fog::Backblaze::TokenCache::FileTokenCache), true)
+    assert_equal(connection.token_cache.instance_variable_get('@file'), 'file.txt')
+  end
+end


### PR DESCRIPTION
`@token_cache` setter in `Fog::Backblaze::Storage::Real` was calling the instance variable (through `attr_reader`) rather than the provided options, making it impossible to set a custom token cache.

Fixed the calls and added tests for integrity.