### PR TITLE
Use string Hash indexes in put_object instead of symbols

### DIFF
--- a/lib/fog/backblaze/storage/real.rb
+++ b/lib/fog/backblaze/storage/real.rb
@@ -268,10 +268,10 @@ class Fog::Backblaze::Storage::Real
       url: upload_url['uploadUrl'],
       body: content,
       headers: {
-        'Authorization': upload_url['authorizationToken'],
-        'Content-Type': 'b2/x-auto',
-        'X-Bz-File-Name': "#{b2_url_encode(file_path)}",
-        'X-Bz-Content-Sha1': Digest::SHA1.hexdigest(content)
+        'Authorization' => upload_url['authorizationToken'],
+        'Content-Type' => 'b2/x-auto',
+        'X-Bz-File-Name' => "#{b2_url_encode(file_path)}",
+        'X-Bz-Content-Sha1' => Digest::SHA1.hexdigest(content)
       }.merge(extra_headers)
     )
 


### PR DESCRIPTION
The `{'foo': 'bar'}` syntax represents a Hash with index `:foo`. Calls to merge that Hash with `{'foo' => 'bar'}` result in a Hash with two distinct elements instead of the original value being overridden. This manifested itself in `put_object` as the `content_type` option being ignored. There was also a duplicate `Authorization` header sent.

More details:
- https://github.com/fog/fog-backblaze/issues/14
- https://github.com/fog/fog-backblaze/pull/15