### PR TITLE
Add option argument and allow bucket objects to have a prefix

### DIFF
--- a/lib/fog/backblaze/storage/models/directories.rb
+++ b/lib/fog/backblaze/storage/models/directories.rb
@@ -6,10 +6,14 @@ class Fog::Backblaze::Storage::Directories < Fog::Collection
     load(data.body['buckets'])
   end
 
-  def get(name)
+  def get(name, options = {})
     list_response = service.list_buckets
     bucket = list_response.json['buckets'].detect {|bucket| bucket['bucketName'] == name }
-    return new(bucket) if bucket
+
+    if bucket
+      directory = new(bucket).merge_attributes(options)
+      return directory
+    end
   end
 
 end

--- a/lib/fog/backblaze/storage/models/directory.rb
+++ b/lib/fog/backblaze/storage/models/directory.rb
@@ -6,6 +6,8 @@ class Fog::Backblaze::Storage::Directory < Fog::Model
   attribute :bucket_type#,     aliases: 'bucketType'
   attribute :cors_rules#,      aliases: 'corsRules'
   attribute :lifecycle_rules#, aliases: 'lifecycleRules'
+  attribute :prefix,           aliases: 'prefix'
+
   attribute :revision
 
   alias_method :name, :key
@@ -17,6 +19,7 @@ class Fog::Backblaze::Storage::Directory < Fog::Model
     attrs['bucket_type']     = attrs['bucketType']
     attrs['cors_rules']      = attrs['corsRules']
     attrs['lifecycle_rules'] = attrs['lifecycleRules']
+    attrs['prefix']          = attrs['Prefix']
 
     super(attrs)
   end
@@ -61,7 +64,7 @@ class Fog::Backblaze::Storage::Directory < Fog::Model
   end
 
   def files
-    @files ||= Fog::Backblaze::Storage::Files.new(directory: self, service: service)
+    @files ||= Fog::Backblaze::Storage::Files.new(directory: self, service: service).all(prefix: prefix)
   end
 
   def public?


### PR DESCRIPTION
This is a small change to be in convention with other fog libraries that I hope will work great with Asset Sync. Which is a great tool for synchronizing assets across multiple Cloud Storage services.

To understand the reason for this change please refer to this other fog library below where they're taking this argument on the same method. I should make a disclaimer though: I could not yet give an use to this argument inside the method as of yet. Even though, it should make it compatible with Asset Sync just immediately without any problems.

https://github.com/fog/fog-aws/blob/master/lib/fog/aws/models/storage/directories.rb#L14

You can also look though this:

https://github.com/fog/fog-azure-rm/blob/master/lib/fog/azurerm/models/storage/directories.rb#L38